### PR TITLE
Create DSL version of Structurizr theme

### DIFF
--- a/diagrams/README.md
+++ b/diagrams/README.md
@@ -10,7 +10,7 @@ and expanded from there to suit our needs.
 
 > [!IMPORTANT]
 > The Git for Confluence plugin we use to include Structurizr diagrams does not honor a
-> theme URL at this time. Use the `theme.dsl` instead, until further notice. 
+> theme URL at this time. For now, use the `theme.dsl` instead. 
 
 **Helpful Links**
 - [Structurizr Themes](https://structurizr.com/help/themes)

--- a/diagrams/theme.dsl
+++ b/diagrams/theme.dsl
@@ -1,0 +1,46 @@
+workspace {
+
+    views {
+        styles {
+            element "Element" {
+                shape RoundedBox
+            }
+            element "Person" {
+                background #08427b
+                color #ffffff
+                shape Person
+            }
+            element "Software System" {
+                background #1168bd
+                color #ffffff
+            }
+            element "Container" {
+              background #438dd5
+              color #ffffff
+            }
+            element "Component" {
+              background #85bbf0
+              color #000000
+            }
+            element "Infrastructure Node" {
+              background #ffffff
+            }
+            element "Focused System" {
+                background #1168bd
+                color #ffffff
+            }
+            element "Web Browser" {
+              shape WebBrowser
+            }
+            element "Mobile App" {
+              shape MobileDeviceLandscape
+            }
+            element "Database" {
+              shape Cylinder
+            }
+            element "External" {
+              background #888888
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Changes

- Create `dsl` version of our theme to work around the Git for Confluence issue.
- Tweak README.

## Review Notes
I'll update the Architecture Diagrams document in Confluence once I've actually got something working reasonably well.